### PR TITLE
Add a link to the projects's codebase in the project's tab as well.

### DIFF
--- a/template.html
+++ b/template.html
@@ -109,7 +109,7 @@
                         {% for project in projects %}
                         {% if project.tickets %}
                         <div class="main-page-section">
-                            <h2><a name="{{ project.name }}">{{ project.name }}</a></h2>
+                            <h2><a href="{{ project.url }}" name="{{ project.name }}">{{ project.name }}</a></h2>
                             <p>
                             To get started contact <a
                             href="mailto:{{ project.owner }}@fedoraproject.org">


### PR DESCRIPTION
I don't think that it's very intuitive to not have the links to the project's code base in the projects' tabs in the easy fix page. It took me quite some time to find the project links of the right hand side of the page.
