### PR TITLE
fix redhat logo path to make it show up again

### DIFF
--- a/template.html
+++ b/template.html
@@ -66,7 +66,7 @@
         <div class="grid_1"> <!-- search filler --></div>
         <div class="grid_6" id="site-heading-rh">
             <a href="https://redhat.com">A Red Hat-Sponsored Community Project
-            <img id="rh-community" src="https://fedoraproject.org/static/images/sponsors/redhat-community.png"
+            <img id="rh-community" src="https://getfedora.org/static/images/sponsors/redhat-community.png"
             alt="Red Hat Logo" /></a>
         </div>
         <div class="clear"></div>
@@ -252,7 +252,7 @@
 
                 <div id="footer" class="grid_12">
                     <a href="https://www.redhat.com/"><img class="rh-logo"
-                        src="https://fedoraproject.org/static/images/sponsors/sidebar/redhat.png" alt="Red Hat Logo" /></a>
+                        src="https://getfedora.org/static/images/sponsors/sidebar/redhat.png" alt="Red Hat Logo" /></a>
                     <p class="sponsor">Fedora is sponsored by Red Hat.</p>
                     <p class="sponsor"><a href="https://www.redhat.com/rhel/fedora/">Learn more about the relationship between Red Hat and Fedora &gt;</a></p>
                     <p class="copy">(C) 2011 Red Hat, Inc. and others.</p>


### PR DESCRIPTION
See webticket #389.
https://fedorahosted.org/fedora-websites/ticket/389