### PR TITLE
Add support for gitlab projects

### DIFF
--- a/gather_easyfix.py
+++ b/gather_easyfix.py
@@ -279,8 +279,7 @@ def main():
                     ticketobj = Ticket()
                     ticketobj.id = ticket['id']
                     ticketobj.title = ticket['title']
-                    ticketobj.url = 'https://gitlab.com/%s/issue/%s' % (
-                        project.name, ticket['id'])
+                    ticketobj.url = ticket['web_url']
                     ticketobj.status = ticket['state']
                     tickets.append(ticketobj)
         else:

--- a/gather_easyfix.py
+++ b/gather_easyfix.py
@@ -261,6 +261,28 @@ def main():
                         project.name, ticket['id'])
                     ticketobj.status = ticket['status']
                     tickets.append(ticketobj)
+        elif project.name.startswith('gitlab.com:'):
+            # https://docs.gitlab.com/ee/api/issues.html#list-project-issues
+            project.name = project.name.split('gitlab.com:')[1]
+            project.url = 'https://gitlab.com/%s/' % (project.name)
+            project.site = 'gitlab.com'
+            url = 'https://gitlab.com/api/v4/projects/%s/issues' \
+                '?state=opened&labels=%s' % (urllib2.quote(project.name,
+                                                           safe=''),
+                                             project.tag)
+            stream = urllib2.urlopen(url)
+            output = stream.read()
+            jsonobj = json.loads(output)
+            if jsonobj:
+                for ticket in jsonobj:
+                    ticket_num = ticket_num + 1
+                    ticketobj = Ticket()
+                    ticketobj.id = ticket['id']
+                    ticketobj.title = ticket['title']
+                    ticketobj.url = 'https://gitlab.com/%s/issue/%s' % (
+                        project.name, ticket['id'])
+                    ticketobj.status = ticket['state']
+                    tickets.append(ticketobj)
         else:
             project.url = 'https://fedorahosted.org/%s/' % (project.name)
             project.site = 'trac'


### PR DESCRIPTION
I've tested it out with a test script like so, and it works:

```python

#!/usr/bin/env python2
"""
Enter one line description here.

File:

Copyright 2018 Ankur Sinha
Author: Ankur Sinha <sanjay DOT ankur AT gmail DOT com>
"""

import json
import urllib2


class Project(object):
    """ Simple object representation of a project. """

    def __init__(self):
        self.name = ""
        self.url = ""
        self.site = ""
        self.owner = ""
        self.tag = ""
        self.tickets = []


class Ticket(object):
    """ Simple object representation of a ticket. """

    def __init__(self):
        self.id = ""
        self.url = ""
        self.title = ""
        self.status = ""
        self.type = ""
        self.component = ""


project = Project()
ticket_num = 0

project.name = "gitlab.com:sanjayankur31/Sinha2016-scripts"
project.tag = "Bug"

project.name = project.name.split('gitlab.com:')[1]
project.url = 'https://gitlab.com/%s/' % (project.name)
project.site = 'gitlab.com'
url = 'https://gitlab.com/api/v4/projects/%s/issues' \
    '?state=opened&labels=%s' % (urllib2.quote(project.name,
                                               safe=''),
                                 project.tag)

stream = urllib2.urlopen(url)
output = stream.read()
jsonobj = json.loads(output)
print(jsonobj)

if jsonobj:
    for ticket in jsonobj:
        ticket_num = ticket_num + 1
        ticketobj = Ticket()
        ticketobj.id = ticket['id']
        ticketobj.title = ticket['title']
        ticketobj.url = ticket['web_url']
        ticketobj.status = ticket['state']
```